### PR TITLE
#11 Commit multiple files in a single cvs command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,7 +11,7 @@ import {ExtensionChannel} from './log';
 import Utils from './utils';
 import * as cvs_commit from './commit';
 import * as cvs_add from './add';
-import * as cvs_remove from './remove'
+import * as cvs_remove from './remove';
 import * as cvs_show_changes from './show_changes';
 import * as cvs_checkout from './checkout';
 import * as cvs_compare from './compare';

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -46,7 +46,7 @@ class CommitOpenedFile implements ICommit {
     async commit(vdb: ExtensionVDB, logger: ExtensionChannel) {
         const cvs = new CVS(this.m_CVSRoot, this.m_WorkDir, vdb, logger);
 
-        const code = await cvs.onCommit(this.m_OpenedFilePath, this.m_Comment);
+        const code = await cvs.onCommit([this.m_OpenedFilePath], this.m_Comment);
         if (code) {
             return new ErrorMessage(
                 `Unable to commit opened file in current window: ${this.m_OpenedFilePath} to repository`
@@ -86,14 +86,17 @@ class CommitContent implements ICommit {
 
     async commit(vdb: ExtensionVDB, logger: ExtensionChannel) {
         const cvs = new CVS(this.m_CVSRoot, this.m_WorkDir, vdb, logger);
-        for (const file of this.m_FilePaths) {
-            const code = await cvs.onCommit(file, this.m_Comment);
+        if (this.m_FilePaths.length > 0) {
+            const code = await cvs.onCommit(this.m_FilePaths, this.m_Comment);
             if (code) {
-                new ErrorMessage(`Unable to commit selected file: ${file} to repository`).show();
+                new ErrorMessage(`Unable to commit selected files: "${this.m_FilePaths.join(" ")}" to repository`).show();
             }
             else {
-                new InfoMessage(`Selected file: ${file} has been commited to repository`).show();
+                new InfoMessage(`Selected files: "${this.m_FilePaths.join(" ")}" have been commited to repository`).show();
             }
+        }
+        else {
+            new ErrorMessage(`No files have been selected to be committed`).show();
         }
     }
 }

--- a/src/cvs.ts
+++ b/src/cvs.ts
@@ -100,10 +100,10 @@ class CVS {
         });
     }
 
-    onCommit(path: string, comment: string): Promise<number> {
+    onCommit(paths: string[], comment: string): Promise<number> {
         const proc = spawn(
             'cvs', 
-            ['-d', this.m_CVSRoot, 'commit', '-m', comment, path], 
+            ['-d', this.m_CVSRoot, 'commit', '-m', comment].concat(paths), 
             {cwd: this.m_WorkDir}
         );
 


### PR DESCRIPTION
Resolved issue #11 by changing the commit command to send multiple file in a single command instead of a separate command for each file.